### PR TITLE
Fix table formatting

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -23,7 +23,7 @@ Request Priority | Description of the Request Priority
 
 Stakater offers three levels of support tiers, as described in the table below.
 
- | Essential | Advanced | Premium
+Feature | Essential | Advanced | Premium
 --- | --- | --- | ---
 Use case | Basic minimum support | Development support | Production and critical workload support
 Support hours | 24x5x365 | 24x7x365 | 24x7x365


### PR DESCRIPTION
First column needs a word for it to be formatted properly, currently looking like:

![Screenshot 2025-01-21 at 08 33 27](https://github.com/user-attachments/assets/11d13566-80bf-41d7-9018-b46e03f4db9e)
